### PR TITLE
Standardize Attribute VB_Name for modules

### DIFF
--- a/VB3 Decompiler OCX/MODULE3.BAS
+++ b/VB3 Decompiler OCX/MODULE3.BAS
@@ -1,3 +1,4 @@
+Attribute VB_Name = "Module3"
 ' Module3
 Option Explicit
 

--- a/VB3 Decompiler OCX/MODULE4.BAS
+++ b/VB3 Decompiler OCX/MODULE4.BAS
@@ -1,4 +1,4 @@
-Attribute VB_Name = "MODULE4"
+Attribute VB_Name = "Module4"
 ' Module4
 Option Explicit
 Dim m000E As T148E

--- a/VB3 Decompiler OCX/MODULE5.BAS
+++ b/VB3 Decompiler OCX/MODULE5.BAS
@@ -1,4 +1,4 @@
-Attribute VB_Name = "MODULE5"
+Attribute VB_Name = "Module5"
 ' Module5
 Option Explicit
 Declare Function extfn0529 Lib "Kernel32" Alias "GetPrivateProfileStringA" (ByVal p1$, ByVal p2$, ByVal p3$, ByVal p4$, ByVal p5%, ByVal p6$) As Integer

--- a/VB3 Decompiler OCX/MODULE7.BAS
+++ b/VB3 Decompiler OCX/MODULE7.BAS
@@ -1,3 +1,4 @@
+Attribute VB_Name = "Module7"
 ' Module7
 Option Explicit
 

--- a/VB3 Decompiler OCX/MODULE8.BAS
+++ b/VB3 Decompiler OCX/MODULE8.BAS
@@ -1,3 +1,4 @@
+Attribute VB_Name = "Module8"
 ' Module8
 Option Explicit
 

--- a/VB3 Decompiler OCX/MODULE9.BAS
+++ b/VB3 Decompiler OCX/MODULE9.BAS
@@ -1,2 +1,3 @@
+Attribute VB_Name = "Module9"
 ' Module9
 Option Explicit


### PR DESCRIPTION
This PR is trivial, but it should fix language detection issues for VB6 modules.

It should make sure that the language stats bar is this:

![image](https://github.com/VBGAMER45/Semi-VB-Decompiler/assets/31558169/430bd9cd-0ac8-4b4a-bd93-7d8a67f77df2)

Instead of this:

![image](https://github.com/VBGAMER45/Semi-VB-Decompiler/assets/31558169/5d7122ac-89f1-4ba9-934c-48bb470c4e23)
